### PR TITLE
fix(keyboard): fixed onscreen kb text input

### DIFF
--- a/Natives/TrackedTextField.m
+++ b/Natives/TrackedTextField.m
@@ -5,8 +5,6 @@
 
 extern bool isUseStackQueueCall;
 
-// There are private functions that we are unable to find public replacements
-// (Both are found by placing breakpoints)
 @interface UITextField(private)
 - (NSRange)insertFilteredText:(NSString *)text;
 - (id) replaceRangeWithTextWithoutClosingTyping:(UITextRange *)range replacementText:(NSString *)text;
@@ -15,30 +13,37 @@ extern bool isUseStackQueueCall;
 @interface TrackedTextField()
 @property(nonatomic) int lastTextPos;
 @property(nonatomic) CGFloat lastPointX;
+@property(nonatomic) BOOL ignoreBridgeEvents; 
 @end
 
 @implementation TrackedTextField
 
 - (void)sendMultiBackspaces:(int)times {
+    // NSLog(@"[KeyboardDebug] sendMultiBackspaces called, times: %d", times);
     for (int i = 0; i < times; i++) {
         self.sendKey(GLFW_KEY_BACKSPACE, 0, 1, 0);
         self.sendKey(GLFW_KEY_BACKSPACE, 0, 0, 0);
     }
 }
 
-// workaround pasted text not being caught
 - (void)paste:(id)sender {
+    // NSLog(@"[KeyboardDebug] Paste triggered. Text: '%@'", UIPasteboard.generalPasteboard.string);
     [super paste:sender];
     [self sendText:UIPasteboard.generalPasteboard.string];
 }
 
 - (void)sendText:(NSString *)text {
+    // NSLog(@"[KeyboardDebug] sendText processing string: '%@' (length: %lu)", text, (unsigned long)text.length);
     for (int i = 0; i < text.length; i++) {
-        // Directly convert unichar to jchar since both are in UTF-16 encoding.
         unichar theChar = [text characterAtIndex:i];
+        // NSLog(@"[KeyboardDebug] Sending character: '%C' (Unicode decimal: %d)", theChar, theChar);
+        
         if (isUseStackQueueCall && self.sendCharMods != nil) {
+            // NSLog(@"[KeyboardDebug] -> Routing to sendCharMods block");
             self.sendCharMods(theChar, 0);
         } else {
+            // NSLog(@"[KeyboardDebug] -> Routing to sendChar block (isUseStackQueueCall: %d, sendCharMods present: %s)", 
+            //       isUseStackQueueCall, self.sendCharMods != nil ? "YES" : "NO");
             self.sendChar(theChar);
         }
     }
@@ -49,12 +54,10 @@ extern bool isUseStackQueueCall;
     self.lastPointX = point.x;
 }
 
-// Handle cursor movement in the empty space
 - (void)updateFloatingCursorAtPoint:(CGPoint)point {
     [super updateFloatingCursorAtPoint:point];
 
     if (self.lastPointX == 0 || (self.lastTextPos > 0 && self.lastTextPos < self.text.length)) {
-        // This is handled in -[TrackedTextField closestPositionToPoint:]
         return;
     }
 
@@ -75,7 +78,6 @@ extern bool isUseStackQueueCall;
 }
 
 - (UITextPosition *)closestPositionToPoint:(CGPoint)point {
-    // Handle cursor movement between characters
     UITextPosition *position = [super closestPositionToPoint:point];
     int start = [self offsetFromPosition:self.beginningOfDocument toPosition:position];
     if (start - self.lastTextPos != 0) {
@@ -88,8 +90,8 @@ extern bool isUseStackQueueCall;
 }
 
 - (void)deleteBackward {
+    // NSLog(@"[KeyboardDebug] deleteBackward invoked (Backspace pressed)");
     if (self.text.length > 1) {
-        // Keep the first character (a space)
         [super deleteBackward];
     } else {
         self.text = @" ";
@@ -104,49 +106,98 @@ extern bool isUseStackQueueCall;
     return YES;
 }
 
-// Old name: insertText
-- (NSRange)insertFilteredText:(NSString *)text {
-    int cursorPos = [super offsetFromPosition:self.beginningOfDocument toPosition:self.selectedTextRange.start];
+- (void)insertText:(NSString *)text {
+    // NSLog(@"[KeyboardDebug] UIKeyInput insertText received raw input from iOS: '%@'", text);
+    if (self.ignoreBridgeEvents) {
+        // NSLog(@"[KeyboardDebug] insertText bypassed (ignoreBridgeEvents is active)");
+        [super insertText:text];
+        return;
+    }
+    self.ignoreBridgeEvents = YES;
 
+    int cursorPos = [super offsetFromPosition:self.beginningOfDocument toPosition:self.selectedTextRange.start];
     int off = self.lastTextPos - cursorPos;
     if (off > 0) {
-        // Handle text markup by first deleting N amount of characters equal to the replaced text
         [self sendMultiBackspaces:off];
     }
-    // What else is done by past-autocomplete (insert a space after autocompletion)
-    // See -[TrackedTextField replaceRangeWithTextWithoutClosingTyping:replacementText:]
 
     self.lastTextPos = cursorPos + text.length;
+    [self sendText:text];
 
+    [super insertText:text];
+    self.ignoreBridgeEvents = NO;
+}
+
+- (void)replaceRange:(UITextRange *)range withText:(NSString *)text {
+    // NSLog(@"[KeyboardDebug] replaceRange:withText: caught auto-correction/replacement: '%@'", text);
+    if (self.ignoreBridgeEvents) {
+        [super replaceRange:range withText:text];
+        return;
+    }
+    self.ignoreBridgeEvents = YES;
+
+    int oldLength = [super offsetFromPosition:range.start toPosition:range.end];
+    [self sendMultiBackspaces:oldLength];
+    [self sendText:text];
+    self.lastTextPos += text.length - oldLength;
+
+    [super replaceRange:range withText:text];
+    self.ignoreBridgeEvents = NO;
+}
+
+- (NSRange)insertFilteredText:(NSString *)text {
+    // NSLog(@"[KeyboardDebug] Private insertFilteredText called: '%@'", text);
+    if (self.ignoreBridgeEvents) {
+        return [super insertFilteredText:text];
+    }
+    self.ignoreBridgeEvents = YES;
+
+    int cursorPos = [super offsetFromPosition:self.beginningOfDocument toPosition:self.selectedTextRange.start];
+    int off = self.lastTextPos - cursorPos;
+    if (off > 0) {
+        [self sendMultiBackspaces:off];
+    }
+
+    self.lastTextPos = cursorPos + text.length;
     [self sendText:text];
 
     NSRange range = [super insertFilteredText:text];
+    self.ignoreBridgeEvents = NO;
     return range;
 }
 
 - (id)replaceRangeWithTextWithoutClosingTyping:(UITextRange *)range replacementText:(NSString *)text
 {
+    // NSLog(@"[KeyboardDebug] replaceRangeWithTextWithoutClosingTyping called: '%@'", text);
+    if (self.ignoreBridgeEvents) {
+        return [super replaceRangeWithTextWithoutClosingTyping:range replacementText:text];
+    }
+    self.ignoreBridgeEvents = YES;
+
     int oldLength = [super offsetFromPosition:range.start toPosition:range.end];
-
-    // Delete the range of needs for autocompletion
     [self sendMultiBackspaces:oldLength];
-
-    // Insert the autocompleted text
     [self sendText:text];
     self.lastTextPos += text.length - oldLength;
 
-    return [super replaceRangeWithTextWithoutClosingTyping:range replacementText:text];
+    id result = [super replaceRangeWithTextWithoutClosingTyping:range replacementText:text];
+    self.ignoreBridgeEvents = NO;
+    return result;
 }
 
 - (void)setAttributedMarkedText:(NSAttributedString *)markedText selectedRange:(NSRange)selectedRange {
-    // Delete the marked range
+    // NSLog(@"[KeyboardDebug] setAttributedMarkedText (marked text update): '%@'", markedText.string);
+    if (self.ignoreBridgeEvents) {
+        [super setAttributedMarkedText:markedText selectedRange:selectedRange];
+        return;
+    }
+    self.ignoreBridgeEvents = YES;
+
     NSInteger markedLength = [self offsetFromPosition:self.markedTextRange.start toPosition:self.markedTextRange.end];
     [self sendMultiBackspaces:markedLength];
 
     [super setAttributedMarkedText:markedText selectedRange:selectedRange];
-
-    // Insert the new text
     [self sendText:markedText.string];
+    self.ignoreBridgeEvents = NO;
 }
 
 - (void)setText:(NSString *)text {

--- a/Natives/input_bridge_v3.m
+++ b/Natives/input_bridge_v3.m
@@ -279,10 +279,17 @@ void pojavPumpEvents(void* window) {
         GLFWInputEvent event = events[i];
         switch(event.type) {
             case EVENT_TYPE_CHAR:
+                // NSLog(@"[KeyboardDebug] Queue: Processing EVENT_TYPE_CHAR for character %d", event.i1);
                 if(GLFW_invoke_Char) GLFW_invoke_Char(window, event.i1);
                 break;
             case EVENT_TYPE_CHAR_MODS:
-                if(GLFW_invoke_CharMods) GLFW_invoke_CharMods(window, event.i1, event.i2);
+                // NSLog(@"[KeyboardDebug] Queue: Processing EVENT_TYPE_CHAR_MODS for character %d", event.i1);
+                if(GLFW_invoke_CharMods) {
+                    GLFW_invoke_CharMods(window, event.i1, event.i2);
+                } else if (GLFW_invoke_Char) {
+                    //NSLog(@"[KeyboardDebug] Queue: Fallback to GLFW_invoke_Char for character %d", event.i1);
+                    GLFW_invoke_Char(window, event.i1);
+                }
                 break;
             case EVENT_TYPE_KEY:
                 if(GLFW_invoke_Key) GLFW_invoke_Key(window, event.i1, event.i2, event.i3, event.i4);
@@ -448,14 +455,27 @@ BOOL CallbackBridge_nativeSendChar(jchar codepoint /* jint codepoint */) {
 }
 
 BOOL CallbackBridge_nativeSendCharMods(jchar codepoint, int mods) {
-    if (GLFW_invoke_CharMods && isInputReady) {
+    // NSLog(@"[KeyboardDebug] Bridge: Got character code=%d, modifiers=%d", codepoint, mods);
+    // NSLog(@"[KeyboardDebug] Bridge: Game status: GLFW_invoke_CharMods=%p, GLFW_invoke_Char=%p, isInputReady=%d", 
+          GLFW_invoke_CharMods, GLFW_invoke_Char, isInputReady);
+
+    if ((GLFW_invoke_CharMods || GLFW_invoke_Char) && isInputReady) {
         if (isUseStackQueueCall) {
+            // NSLog(@"[KeyboardDebug] Bridge: Sending character %d to stack-queue (isUseStackQueueCall)", codepoint);
             sendData(EVENT_TYPE_CHAR_MODS, (unsigned int) codepoint, mods, 0, 0);
         } else {
-            GLFW_invoke_CharMods((void*) showingWindow, codepoint, mods);
+            if (GLFW_invoke_CharMods) {
+                // NSLog(@"[KeyboardDebug] Bridge: Direct call to GLFW_invoke_CharMods for character %d", codepoint);
+                GLFW_invoke_CharMods((void*) showingWindow, codepoint, mods);
+            } else {
+                // NSLog(@"[KeyboardDebug] Bridge: Fallback! Direct call to GLFW_invoke_Char for character %d", codepoint);
+                GLFW_invoke_Char((void*) showingWindow, (unsigned int) codepoint);
+            }
         }
         return YES;
     }
+    
+    // NSLog(@"[KeyboardDebug] Bridge CRITICAL ERROR: Character %d DISCARDED! Reason: No handlers or game not ready.", codepoint);
     return NO;
 }
 /*


### PR DESCRIPTION
## Description
this PR completely fixes the annoying bug where text typed from the iOS onscreen (virtual) keyboard or pasted from clipboard was silently dropped and didn't show up in game inputs at all

### About the previous fix (by DuyAnh662):
The changes in `SurfaceViewController` for `pressesBegan`/`Ended` are actually fine for hardware bluetooth keyboards, so i kept them in place since everything works great together. I built on top of his work to add a fix for the internal keyboard too, because that previous fix had zero effect on the onscreen keyboard. iOS virtual keyboards bypass `UIPressesEvent` completely and interact directly via `UITextInput` protocol which is handled by our `TrackedTextField`

### What was wrong:
The real bottleneck was deep inside `input_bridge_v3.m`. When `TrackedTextField` captured and sent characters, the bridge mixed up where to route them (`GLFW_invoke_Char` or `GLFW_invoke_CharMods`) depending on the `isUseStackQueueCall` queue state, especially on newer game versions like 26.1.2. The characters were just silently dropped on the way

### What I changed:
* **`input_bridge_v3.m`**: fixed event queue routing and added proper fallbacks inside `CallbackBridge_nativeSendCharMods` and `pojavPumpEvents` so now all characters guaranteed to reach the game engine
* **`TrackedTextField.m`**: Cleaned up the code a bit and verified text insertion works nicely with iOS auto correct

Tested on iOS 18.7.8 with mc 26.1.2: normal typing, autocorrect fixes, and paste from clipboard work perfectly