### PR TITLE
Enable MirrorMappedCodeCache for all Java versions

### DIFF
--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -405,16 +405,10 @@ int launchJVM(NSString *username, id launchTarget, int width, int height, int mi
     margv[++margc] = "-XX:ParallelGCThreads=2";
 
     // On iOS 26+, use mirror mapped JIT for better code cache performance.
-    // JDK 25 (jre25-ios-v1) has a bug in MirrorMappedCodeCache that causes
-    // SIGBUS in ScavengableNMethods::register_nmethod during JIT compilation.
-    // jre25-ios-v2 is supposed to fix this, but keep the flag off for Java 25
-    // until v2 is confirmed stable across all devices.
-    NSString *currentJavaHome = [NSString stringWithUTF8String:getenv("JAVA_HOME") ?: ""];
-    BOOL isJava25Home = [currentJavaHome containsString:@"java-25"];
+    // JDK 25 (jre25-ios-v10+) has the mirror_mapping HotSpot patch applied,
+    // so MirrorMappedCodeCache works correctly. Enable for all Java versions.
     if (@available(iOS 26.0, *)) {
-        if (!isJava25Home) {
-            margv[++margc] = "-XX:+MirrorMappedCodeCache";
-        }
+        margv[++margc] = "-XX:+MirrorMappedCodeCache";
     }
 
     // Disable Forge 1.16.x early progress window


### PR DESCRIPTION
Updated JDK version handling for MirrorMappedCodeCache on iOS.
Fix on iOS 26.5
Reason: On the iPhone 17 Pro Max (iOS 26.5.2) with the A19 Pro chip, Apple uses hardware TXM to execute W^X instead of the older APRR. The JRE25 ​​is built with the fixup requirements mirror_w/mirror_x -XX:+MirrorMappedCodeCache to create a double mapping (RW + RX) for the code cache. When the flag is omitted, the code cache only has RX, writing to it → SIGBUS BUS_ADRALN right at StubRoutines::call_stub when initializing java/lang/String.

I tested it on a device using iOS 26.5 and it actually works, at least on mine.