### PR TITLE
Fix Java 25 on iOS 26.6/27 with MobileGlues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,10 @@ jre: native
 	if [ -f "$(ls jre*.tar.xz)" ]; then rm $(SOURCEDIR)/depends/jre*.tar.xz; fi; \
 	cd $(SOURCEDIR); \
 	bash $(SOURCEDIR)/scripts/build_jre25.sh; \
+	python3 $(SOURCEDIR)/scripts/patch_jre_mirror_runtime.py 17 $(POJAV_JRE17_DIR)/lib/server/libjvm.dylib; \
+	python3 $(SOURCEDIR)/scripts/patch_jre_mirror_runtime.py --check 17 $(POJAV_JRE17_DIR)/lib/server/libjvm.dylib; \
+	python3 $(SOURCEDIR)/scripts/patch_jre_mirror_runtime.py 21 $(POJAV_JRE21_DIR)/lib/server/libjvm.dylib; \
+	python3 $(SOURCEDIR)/scripts/patch_jre_mirror_runtime.py --check 21 $(POJAV_JRE21_DIR)/lib/server/libjvm.dylib; \
 	rm -rf $(SOURCEDIR)/depends/java-{8,17,21}-openjdk/{ASSEMBLY_EXCEPTION,bin,include,jre,legal,LICENSE,man,THIRD_PARTY_README,lib/{ct.sym,jspawnhelper,libjsig.dylib,src.zip,tools.jar}}; \
 	$(call METHOD_DIRCHECK,$(OUTPUTDIR)/java_runtimes); \
 	cp -R $(POJAV_JRE8_DIR) $(OUTPUTDIR)/java_runtimes; \

--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -181,54 +181,42 @@ void init_loadCustomJvmFlags(int* argc, const char** argv) {
     }
 }
 
+static BOOL RuntimeSupportsDebugJITMapping(NSString *javaHome) {
+    NSString *marker = [javaHome
+        stringByAppendingPathComponent:@".amethyst-mirror-mapping"];
+    NSString *contents = [NSString stringWithContentsOfFile:marker
+        encoding:NSUTF8StringEncoding error:nil];
+    return [contents isEqualToString:@"amethyst-mirror-mapping-v1\n"];
+}
+
+static NSString *BundledDebugJITRuntime(int minimumVersion) {
+    NSArray<NSNumber *> *supportedVersions = @[@17, @21, @25];
+    for (NSNumber *version in supportedVersions) {
+        if (version.intValue < minimumVersion) continue;
+        NSString *javaHome = [NSString stringWithFormat:
+            @"%@/java_runtimes/java-%@-openjdk",
+            NSBundle.mainBundle.bundlePath, version];
+        if (RuntimeSupportsDebugJITMapping(javaHome)) {
+            return javaHome;
+        }
+    }
+    return nil;
+}
+
 int launchJVM(NSString *username, id launchTarget, int width, int height, int minVersion) {
     NSLog(@"[JavaLauncher] Beginning JVM launch");
+    const int requiredJavaVersion = minVersion;
 
     init_loadDefaultEnv();
     init_loadCustomEnv();
     init_loadMobileGluesConfig();
 
-    BOOL requiresTXMWorkaround = DeviceHasJITFlags(JIT_FLAG_FORCE_MIRRORED | JIT_FLAG_HAS_TXM);
+    // Custom environment variables may override JIT_FLAGS, so refresh after
+    // loading them. The debug-mapping decision is based on the executable-map
+    // capability test rather than probing Apple's private Preboot layout.
+    DeviceGetJITFlags(YES);
+    BOOL requiresDebugJITMapping = DeviceNeedsDebugJITMapping();
     BOOL jit26AlwaysAttached = getPrefBool(@"debug.debug_always_attached_jit");
-    if (requiresTXMWorkaround) {
-        static void *result;
-        if(!result) result = JIT26CreateRegionLegacy(getpagesize());
-        if ((uint32_t)result != 0x690000E0) {
-            munmap(result, getpagesize());
-            // we can't continue since legacy script only allows calling breakpoint once
-            NSString *inBundleScriptPath = [NSBundle.mainBundle pathForResource:@"UniversalJIT26" ofType:@"js"];
-            NSString *lcAppInfoPath = [NSBundle.mainBundle.bundlePath stringByAppendingPathComponent:@"LCAppInfo.plist"];
-            NSMutableDictionary *lcAppInfo = [NSMutableDictionary dictionaryWithContentsOfFile:lcAppInfoPath];
-            if(lcAppInfo) {
-                // if this is inside LiveContainer, we assign script ourselves and prompt user to restart Amethyst
-                lcAppInfo[@"jitLaunchScriptJs"] = [[NSData dataWithContentsOfFile:inBundleScriptPath] base64EncodedStringWithOptions:0];
-                if([lcAppInfo writeToFile:lcAppInfoPath atomically:YES]) {
-                    showDialog(localize(@"Error", nil), @"Amethyst was launched with a legacy script. We have updated the script to Universal, please restart LiveContainer to continue.");
-                    [PLLogOutputView handleExitCode:1];
-                    return 1;
-                }
-            }
-            [NSFileManager.defaultManager copyItemAtPath:inBundleScriptPath toPath:[NSString stringWithFormat:@"%s/UniversalJIT26.js", getenv("POJAV_HOME")] error:nil];
-            showDialog(localize(@"Error", nil), @"Support for legacy script has been removed. Please switch to Universal JIT script. To import it, long-press on Amethyst when enabling JIT in StikDebug and tap \"Assign Script\", then go to Amethyst's Documents directory and pick it. (on sideloaded StikDebug, the builtin script is named Amethyst-MeloNX.js)");
-            [PLLogOutputView handleExitCode:1];
-            return 1;
-        }
-        JIT26SendJITScript([NSString stringWithContentsOfFile:[NSBundle.mainBundle pathForResource:@"UniversalJIT26Extension" ofType:@"js"]]);
-        JIT26SetDetachAfterFirstBr(!jit26AlwaysAttached);
-        // make sure we don't get stuck in EXC_BAD_ACCESS
-        task_set_exception_ports(mach_task_self(), EXC_MASK_BAD_ACCESS, 0, EXCEPTION_DEFAULT, MACHINE_THREAD_STATE);
-    }
-    if (!requiresTXMWorkaround || jit26AlwaysAttached) {
-        if (jit26AlwaysAttached) {
-            // Only allow StikDebug to catch our breakpoints to prevent any stutters
-            task_set_exception_ports(mach_task_self(), EXC_MASK_ALL & ~EXC_MASK_BREAKPOINT, 0,
-                EXCEPTION_DEFAULT, THREAD_STATE_NONE);
-        }
-        // Activate Library Validation bypass for external runtime and dylibs (JNA, etc)
-        init_bypassDyldLibValidation();
-    } else {
-        NSLog(@"[DyldLVBypass] Hook disabled! Loading unsigned dylib will cause code signature error.");
-    }
 
     BOOL launchJar = NO;
     NSString *gameDir;
@@ -284,7 +272,28 @@ int launchJVM(NSString *username, id launchTarget, int width, int height, int mi
         showDialog(localize(@"Error", nil), [NSString stringWithFormat:localize(@"java.error.missing_runtime", nil),
             isExecuteJar ? [launchTarget lastPathComponent] : PLProfiles.current.selectedProfile[@"lastVersionId"], minVersion]);
         return 1;
-    } else if ([javaHome hasPrefix:@(getenv("POJAV_HOME"))]) {
+    }
+
+    if (requiresDebugJITMapping && !RuntimeSupportsDebugJITMapping(javaHome)) {
+        // JRE 8 predates the mirror-mapping HotSpot option. On iOS 26.6+
+        // direct executable mappings are unavailable, so use the nearest
+        // bundled patched runtime instead of passing an unknown VM option or
+        // crashing in the old APRR path.
+        NSString *fallbackJavaHome = BundledDebugJITRuntime(MAX(minVersion, 17));
+        if (fallbackJavaHome == nil) {
+            UIKit_returnToSplitView();
+            showDialog(localize(@"Error", nil),
+                @"The selected Java runtime cannot create executable code on "
+                 "this iOS version. Install or select the bundled patched "
+                 "Java 17, 21, or 25 runtime.");
+            return 1;
+        }
+        NSLog(@"[JavaLauncher] Runtime %@ lacks debug JIT mapping support; "
+              "using bundled runtime %@", javaHome, fallbackJavaHome);
+        javaHome = fallbackJavaHome;
+    }
+
+    if ([javaHome hasPrefix:@(getenv("POJAV_HOME"))]) {
         // Symlink libawt_xawt.dylib
         NSString *dest = [NSString stringWithFormat:@"%@/lib/libawt_xawt.dylib", javaHome];
         NSString *source = [NSString stringWithFormat:@"%@/Frameworks/libawt_xawt.dylib", NSBundle.mainBundle.bundlePath];
@@ -297,6 +306,46 @@ int launchJVM(NSString *username, id launchTarget, int width, int height, int mi
 
     setenv("JAVA_HOME", javaHome.UTF8String, 1);
     NSLog(@"[JavaLauncher] JAVA_HOME has been set to %@", javaHome);
+
+    if (requiresDebugJITMapping) {
+        static void *result;
+        if(!result) result = JIT26CreateRegionLegacy(getpagesize());
+        if ((uint32_t)result != 0x690000E0) {
+            munmap(result, getpagesize());
+            // we can't continue since legacy script only allows calling breakpoint once
+            NSString *inBundleScriptPath = [NSBundle.mainBundle pathForResource:@"UniversalJIT26" ofType:@"js"];
+            NSString *lcAppInfoPath = [NSBundle.mainBundle.bundlePath stringByAppendingPathComponent:@"LCAppInfo.plist"];
+            NSMutableDictionary *lcAppInfo = [NSMutableDictionary dictionaryWithContentsOfFile:lcAppInfoPath];
+            if(lcAppInfo) {
+                // if this is inside LiveContainer, we assign script ourselves and prompt user to restart Amethyst
+                lcAppInfo[@"jitLaunchScriptJs"] = [[NSData dataWithContentsOfFile:inBundleScriptPath] base64EncodedStringWithOptions:0];
+                if([lcAppInfo writeToFile:lcAppInfoPath atomically:YES]) {
+                    showDialog(localize(@"Error", nil), @"Amethyst was launched with a legacy script. We have updated the script to Universal, please restart LiveContainer to continue.");
+                    [PLLogOutputView handleExitCode:1];
+                    return 1;
+                }
+            }
+            [NSFileManager.defaultManager copyItemAtPath:inBundleScriptPath toPath:[NSString stringWithFormat:@"%s/UniversalJIT26.js", getenv("POJAV_HOME")] error:nil];
+            showDialog(localize(@"Error", nil), @"Support for legacy script has been removed. Please switch to Universal JIT script. To import it, long-press on Amethyst when enabling JIT in StikDebug and tap \"Assign Script\", then go to Amethyst's Documents directory and pick it. (on sideloaded StikDebug, the builtin script is named Amethyst-MeloNX.js)");
+            [PLLogOutputView handleExitCode:1];
+            return 1;
+        }
+        JIT26SendJITScript([NSString stringWithContentsOfFile:[NSBundle.mainBundle pathForResource:@"UniversalJIT26Extension" ofType:@"js"]]);
+        JIT26SetDetachAfterFirstBr(!jit26AlwaysAttached);
+        // make sure we don't get stuck in EXC_BAD_ACCESS
+        task_set_exception_ports(mach_task_self(), EXC_MASK_BAD_ACCESS, 0, EXCEPTION_DEFAULT, MACHINE_THREAD_STATE);
+    }
+    if (!requiresDebugJITMapping || jit26AlwaysAttached) {
+        if (jit26AlwaysAttached) {
+            // Only allow StikDebug to catch our breakpoints to prevent any stutters
+            task_set_exception_ports(mach_task_self(), EXC_MASK_ALL & ~EXC_MASK_BREAKPOINT, 0,
+                EXCEPTION_DEFAULT, THREAD_STATE_NONE);
+        }
+        // Activate Library Validation bypass for external runtime and dylibs (JNA, etc)
+        init_bypassDyldLibValidation();
+    } else {
+        NSLog(@"[DyldLVBypass] Hook disabled! Loading unsigned dylib will cause code signature error.");
+    }
 
     int allocmem;
     if (getPrefBool(@"java.auto_ram")) {
@@ -340,8 +389,16 @@ int launchJVM(NSString *username, id launchTarget, int width, int height, int mi
     const char *glLibName = getenv("AMETHYST_RENDERER");
     if (glLibName) {
         if (!strcmp(glLibName, "auto")) {
-            // workaround only applies to 1.20.2+
-            glLibName = RENDERER_NAME_MTL_ANGLE;
+            // Minecraft versions that require Java 25 can reach texture-buffer
+            // paths unsupported by the bundled ANGLE build. Use MobileGlues
+            // for those versions while retaining the existing auto behavior
+            // for older games.
+            if (!launchJar && requiredJavaVersion >= 25) {
+                glLibName = RENDERER_NAME_MOBILEGLUES;
+                setenv("AMETHYST_RENDERER", glLibName, 1);
+            } else {
+                glLibName = RENDERER_NAME_MTL_ANGLE;
+            }
         }
         // libMoltenVK is a Vulkan loader, not a GL implementation; binding it as
         // opengl.libname makes LWJGL fail looking up GL symbols. The Vulkan
@@ -404,9 +461,10 @@ int launchJVM(NSString *username, id launchTarget, int width, int height, int mi
     margv[++margc] = "-XX:+UseParallelGC";
     margv[++margc] = "-XX:ParallelGCThreads=2";
 
-    // JDK 25 (jre25-ios-v10+) has the mirror_mapping HotSpot patch applied,
-    // so MirrorMappedCodeCache works correctly. Enable for all Java versions.
-    if (@available(iOS 26.0, *)) {
+    // The patched runtimes interpret this flag as permission to request the
+    // debugger-backed RX mapping. Only enable it after the Universal JIT
+    // script has been selected for a device that cannot create RX mappings.
+    if (requiresDebugJITMapping) {
         margv[++margc] = "-XX:+MirrorMappedCodeCache";
     }
     // Disable Forge 1.16.x early progress window

--- a/Natives/LauncherNavigationController.m
+++ b/Natives/LauncherNavigationController.m
@@ -441,7 +441,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         return;
     } else if (@available(iOS 17.4, *)) {
         NSString *scriptDataString = @"";
-        if(DeviceHasJITFlags(JIT_FLAG_FORCE_MIRRORED | JIT_FLAG_HAS_TXM)) {
+        if (DeviceNeedsDebugJITMapping()) {
             NSData *scriptData = [NSData dataWithContentsOfFile:[NSBundle.mainBundle.bundlePath stringByAppendingPathComponent:@"UniversalJIT26.js"]];
             scriptDataString = [@"&script-data=" stringByAppendingString:[scriptData base64EncodedStringWithOptions:0]];
         }

--- a/Natives/LauncherPreferencesViewController.m
+++ b/Natives/LauncherPreferencesViewController.m
@@ -484,7 +484,7 @@
                 @"icon": @"app.connected.to.app.below.fill",
                 @"type": self.typeSwitch,
                 @"enableCondition": ^BOOL(){
-                    return DeviceHasJITFlags(JIT_FLAG_FORCE_MIRRORED | JIT_FLAG_HAS_TXM) && whenNotInGame();
+                    return DeviceNeedsDebugJITMapping() && whenNotInGame();
                 },
             },
             @{@"key": @"debug_skip_wait_jit",

--- a/Natives/utils.h
+++ b/Natives/utils.h
@@ -77,6 +77,7 @@ typedef enum {
 } JITFlags;
 JITFlags DeviceGetJITFlags(BOOL refresh);
 BOOL DeviceHasJITFlags(JITFlags flags);
+BOOL DeviceNeedsDebugJITMapping(void);
 
 // Init functions
 void init_bypassDyldLibValidation();

--- a/Natives/utils.m
+++ b/Natives/utils.m
@@ -2,6 +2,7 @@
 
 #include "jni.h"
 #include <dlfcn.h>
+#include <os/lock.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -198,48 +199,109 @@ BOOL DeviceCanCreateRXMap(void) {
     munmap(map, getpagesize());
     return ret == 0;
 }
+
+static BOOL DeviceLikelyHasTXMFromChipID(void) {
+    NSUInteger (*MGGetSInt64Answer)(NSString *) = dlsym(RTLD_DEFAULT, "MGGetSInt64Answer");
+    if (MGGetSInt64Answer == NULL) {
+        // Failing closed would select the legacy mapping path on the exact
+        // systems where Apple made Preboot unreadable. Prefer the TXM-safe
+        // path on recent systems when MobileGestalt is unavailable.
+        if (@available(iOS 19.0, *)) return YES;
+        return NO;
+    }
+
+    switch (MGGetSInt64Answer(@"ChipID")) {
+        case 0x8020: // A12
+        case 0x8027: // A12X/Z
+            return NO;
+        case 0x8030: // A13
+        case 0x8101: // A14
+        case 0x8103: // M1
+            if (@available(iOS 27.0, *)) return YES;
+            return NO;
+        default:
+            if (@available(iOS 19.0, *)) return YES;
+            return NO;
+    }
+}
+
 BOOL DeviceHasTXM(void) {
+    // Try the direct active-Preboot path before falling back to legacy
+    // directory enumeration.
+    static const char *modernTXMPath =
+        "/System/Volumes/Preboot/boot/usr/standalone/firmware/FUD/"
+        "Ap,TrustedExecutionMonitor.img4";
+    if (access(modernTXMPath, F_OK) == 0) return YES;
+
     DIR *d = opendir("/private/preboot");
-    if(!d) return NO;
+    if (!d) {
+        // /private/preboot is no longer readable on iOS 26.6 and iOS 27.
+        // Fall back to a conservative hardware/OS heuristic.
+        return DeviceLikelyHasTXMFromChipID();
+    }
+
     struct dirent *dir;
-    char txmPath[PATH_MAX];
+    BOOL hasTXM = NO;
     while ((dir = readdir(d)) != NULL) {
         if(strlen(dir->d_name) == 96) {
-            snprintf(txmPath, sizeof(txmPath), "/private/preboot/%s/usr/standalone/firmware/FUD/Ap,TrustedExecutionMonitor.img4", dir->d_name);
-            break;
+            char txmPath[PATH_MAX] = {0};
+            int length = snprintf(txmPath, sizeof(txmPath),
+                "/private/preboot/%s/usr/standalone/firmware/FUD/"
+                "Ap,TrustedExecutionMonitor.img4", dir->d_name);
+            if (length > 0 && (size_t)length < sizeof(txmPath) &&
+                    access(txmPath, F_OK) == 0) {
+                hasTXM = YES;
+                break;
+            }
         }
     }
     closedir(d);
-    return access(txmPath, F_OK) == 0;
+    return hasTXM;
 }
+
 JITFlags DeviceGetJITFlags(BOOL refresh) {
+    static os_unfair_lock cacheLock = OS_UNFAIR_LOCK_INIT;
     static JITFlags cachedFlags = 0;
-    static dispatch_once_t onceToken;
-    if (refresh) onceToken = 0;
-    dispatch_once(&onceToken, ^{
+    static BOOL cacheInitialized = NO;
+
+    os_unfair_lock_lock(&cacheLock);
+    if (refresh || !cacheInitialized) {
+        JITFlags flags = 0;
         const char *s = getenv("JIT_FLAGS");
         if (s) {
             if (s[0] == '0' && tolower(s[1]) == 'b') {
-                cachedFlags = strtoul(s + 2, NULL, 2);
+                flags = strtoul(s + 2, NULL, 2);
             } else {
-                cachedFlags = strtoul(s, NULL, 0);
+                flags = strtoul(s, NULL, 0);
             }
-            NSLog(@"[JIT] Using overridden JIT flags: 0x%X", cachedFlags);
-            return;
-        }
-        
-        if (@available(iOS 26.0, *)) {
-            cachedFlags |= JIT_FLAG_IS_IOS_26;
-            if (!DeviceCanCreateRXMap()) {
-                cachedFlags |= JIT_FLAG_FORCE_MIRRORED;
+            NSLog(@"[JIT] Using overridden JIT flags: 0x%X", flags);
+        } else {
+            if (@available(iOS 26.0, *)) {
+                flags |= JIT_FLAG_IS_IOS_26;
+                if (!DeviceCanCreateRXMap()) {
+                    flags |= JIT_FLAG_FORCE_MIRRORED;
+                }
+            }
+            if (DeviceHasTXM()) {
+                flags |= JIT_FLAG_HAS_TXM;
             }
         }
-        if (DeviceHasTXM()) {
-            cachedFlags |= JIT_FLAG_HAS_TXM;
-        }
-    });
-    return cachedFlags;
+
+        cachedFlags = flags;
+        cacheInitialized = YES;
+    }
+    JITFlags result = cachedFlags;
+    os_unfair_lock_unlock(&cacheLock);
+    return result;
 }
+
 BOOL DeviceHasJITFlags(JITFlags flags) {
     return (DeviceGetJITFlags(NO) & flags) == flags;
+}
+
+BOOL DeviceNeedsDebugJITMapping(void) {
+    // This is a capability decision, not a TXM firmware-detection decision.
+    // MirrorMappedCodeCache now means that the Universal JIT script has been
+    // installed and HotSpot may request its RX mapping from the debugger.
+    return DeviceHasJITFlags(JIT_FLAG_IS_IOS_26 | JIT_FLAG_FORCE_MIRRORED);
 }

--- a/scripts/build_jre25.sh
+++ b/scripts/build_jre25.sh
@@ -1,50 +1,155 @@
 #!/usr/bin/env bash
-# Downloads our iOS-built OpenJDK 25 from the vibecodest/Amethyst-iOS release
-# (built by .github/workflows/build-ios-jdk25.yml from OpenJDK source +
-# scripts/jdk25_ios_fixups.py — actual iOS-targeted compile, not retag).
-#
-# Earlier revision retagged macOS Adoptium binaries; that approach didn't work
-# because OpenJDK has macOS-specific code paths that fail at iOS runtime.
-# This version uses a real iOS-targeted build.
+# Downloads the pinned iOS-built OpenJDK 25 release used by this repository.
+# scripts/jdk25_ios_fixups.py contains the matching source-level fixes for the
+# next runtime rebuild; this downloader installs and validates the published
+# iOS artifact rather than retagging a macOS JRE.
 
 set -euo pipefail
 
 JRE_URL="${JRE_URL:-https://github.com/catsruledogs/JRE25/releases/download/JRE25/jre25-ios-arm64-20260509-release.tar.xz}"
-DEST_DIR="${DEST_DIR:-$(cd "$(dirname "$0")/.." && pwd)/depends/java-25-openjdk}"
-WORK_DIR="${WORK_DIR:-$(mktemp -d -t jre25-XXXXXX)}"
+JRE_SHA256="${JRE_SHA256:-7a58825b72916fabe1530618e4e662f1d7906944b5066eda446944f0751b55dd}"
+SOURCE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DEST_DIR="${DEST_DIR:-$SOURCE_DIR/depends/java-25-openjdk}"
+DEST_PARENT="$(dirname "$DEST_DIR")"
+COMPLETE_MARKER=".amethyst-jre25.complete"
+MIRROR_MARKER=".amethyst-mirror-mapping"
 
-if [ -f "$DEST_DIR/release" ] && [ -f "$DEST_DIR/lib/server/libjvm.dylib" ]; then
-    echo "[jre25] $DEST_DIR already present, skipping download"
-    exit 0
+dest_name="$(basename "$DEST_DIR")"
+if [ "$dest_name" != "java-25-openjdk" ]; then
+    echo "[jre25] ERROR: DEST_DIR must end in java-25-openjdk" >&2
+    exit 1
+fi
+mkdir -p "$DEST_PARENT"
+DEST_PARENT="$(cd "$DEST_PARENT" && pwd -P)"
+DEST_DIR="$DEST_PARENT/$dest_name"
+
+work_dir_owned=0
+if [ -n "${WORK_DIR:-}" ]; then
+    mkdir -p "$WORK_DIR"
+else
+    WORK_DIR="$(mktemp -d -t jre25-work.XXXXXX)"
+    work_dir_owned=1
 fi
 
-echo "[jre25] downloading iOS-built OpenJDK 25 from release..."
-echo "[jre25]   $JRE_URL"
-curl -L --fail -o "$WORK_DIR/jre25.tar.xz" "$JRE_URL"
+staging_root=""
+backup_root=""
+backup_dir=""
+install_in_progress=0
 
-mkdir -p "$DEST_DIR"
-echo "[jre25] extracting to $DEST_DIR..."
-tar xf "$WORK_DIR/jre25.tar.xz" -C "$DEST_DIR"
+cleanup() {
+    status=$?
+    trap - EXIT
+    if [ "$install_in_progress" = "1" ] &&
+            [ -n "$backup_dir" ] &&
+            [ -e "$backup_dir" ]; then
+        if [ ! -e "$DEST_DIR" ]; then
+            mv "$backup_dir" "$DEST_DIR"
+        else
+            echo "[jre25] interrupted after installing the new runtime;" \
+                "previous runtime preserved at $backup_dir" >&2
+            backup_root=""
+        fi
+    fi
+    if [ -n "$staging_root" ] && [ -d "$staging_root" ]; then
+        rm -rf -- "$staging_root"
+    fi
+    if [ -n "$backup_root" ] && [ -d "$backup_root" ]; then
+        rm -rf -- "$backup_root"
+    fi
+    if [ "$work_dir_owned" = "1" ] && [ -d "$WORK_DIR" ]; then
+        rm -rf -- "$WORK_DIR"
+    fi
+    exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
-# Sanity check: libjvm.dylib must exist and be tagged iOS.
-JVM="$DEST_DIR/lib/server/libjvm.dylib"
-JLI="$DEST_DIR/lib/libjli.dylib"
-for required in "$JVM" "$JLI"; do
-    if [ ! -f "$required" ]; then
-        echo "[jre25] ERROR: required dylib missing: $required"
-        find "$DEST_DIR" -name "libjvm*.dylib" -o -name "libjli*.dylib" 2>/dev/null
+runtime_complete() {
+    runtime_dir="$1"
+    [ -f "$runtime_dir/release" ] &&
+        [ -x "$runtime_dir/bin/java" ] &&
+        [ -s "$runtime_dir/lib/modules" ] &&
+        [ -f "$runtime_dir/lib/libjli.dylib" ] &&
+        [ -f "$runtime_dir/lib/server/libjvm.dylib" ] &&
+        [ -d "$runtime_dir/conf" ]
+}
+
+if [ -e "$DEST_DIR" ] && ! runtime_complete "$DEST_DIR"; then
+    echo "[jre25] ERROR: refusing to replace a non-JRE destination: $DEST_DIR" >&2
+    exit 1
+fi
+
+marker_matches() {
+    marker="$1/$COMPLETE_MARKER"
+    [ -f "$marker" ] &&
+        grep -Fxq "archive_sha256=$JRE_SHA256" "$marker"
+}
+
+verify_ios_binary() {
+    jvm="$1/lib/server/libjvm.dylib"
+    if ! vtool -show "$jvm" 2>/dev/null | grep -q "platform IOS"; then
+        echo "[jre25] ERROR: libjvm.dylib is not tagged for iOS" >&2
+        vtool -show "$jvm" >&2 || true
+        return 1
+    fi
+}
+
+if runtime_complete "$DEST_DIR" && marker_matches "$DEST_DIR"; then
+    echo "[jre25] using validated cached runtime: $DEST_DIR"
+    python3 "$SOURCE_DIR/scripts/patch_jre25_runtime.py" \
+        --check "$DEST_DIR/lib/server/libjvm.dylib"
+    verify_ios_binary "$DEST_DIR"
+    printf 'amethyst-mirror-mapping-v1\n' > "$DEST_DIR/$MIRROR_MARKER"
+else
+    archive="$WORK_DIR/jre25.tar.xz"
+    echo "[jre25] downloading pinned iOS OpenJDK 25 artifact..."
+    echo "[jre25]   $JRE_URL"
+    curl -L --fail -o "$archive" "$JRE_URL"
+
+    actual_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+    if [ "$actual_sha256" != "$JRE_SHA256" ]; then
+        echo "[jre25] ERROR: archive SHA-256 mismatch" >&2
+        echo "[jre25] expected: $JRE_SHA256" >&2
+        echo "[jre25] actual:   $actual_sha256" >&2
         exit 1
     fi
-done
 
-# Verify it's an iOS Mach-O (not macOS retag).
-if vtool -show "$JVM" 2>/dev/null | grep -q "platform IOS"; then
-    echo "[jre25] confirmed: libjvm.dylib has platform IOS"
-else
-    echo "[jre25] WARNING: libjvm.dylib is not tagged as iOS. vtool output:"
-    vtool -show "$JVM" || true
+    staging_root="$(mktemp -d "$DEST_PARENT/.jre25-staging.XXXXXX")"
+    staged_runtime="$staging_root/runtime"
+    mkdir -p "$staged_runtime"
+    echo "[jre25] extracting into staging directory..."
+    tar xf "$archive" -C "$staged_runtime"
+
+    if ! runtime_complete "$staged_runtime"; then
+        echo "[jre25] ERROR: extracted runtime is incomplete" >&2
+        exit 1
+    fi
+
+    staged_jvm="$staged_runtime/lib/server/libjvm.dylib"
+    python3 "$SOURCE_DIR/scripts/patch_jre25_runtime.py" "$staged_jvm"
+    python3 "$SOURCE_DIR/scripts/patch_jre25_runtime.py" --check "$staged_jvm"
+    verify_ios_binary "$staged_runtime"
+    printf 'amethyst-mirror-mapping-v1\n' \
+        > "$staged_runtime/$MIRROR_MARKER"
+    printf 'archive_sha256=%s\n' "$JRE_SHA256" \
+        > "$staged_runtime/$COMPLETE_MARKER"
+
+    if [ -e "$DEST_DIR" ]; then
+        backup_root="$(mktemp -d "$DEST_PARENT/.jre25-backup.XXXXXX")"
+        backup_dir="$backup_root/runtime"
+        install_in_progress=1
+        mv "$DEST_DIR" "$backup_dir"
+    fi
+    mv "$staged_runtime" "$DEST_DIR"
+    install_in_progress=0
+    if [ -n "$backup_root" ]; then
+        rm -rf -- "$backup_root"
+        backup_root=""
+        backup_dir=""
+    fi
+    echo "[jre25] installed validated runtime: $DEST_DIR"
 fi
 
-rm -rf "$WORK_DIR"
 echo "[jre25] done. Final size:"
 du -sh "$DEST_DIR"

--- a/scripts/jdk25_ios_fixups.py
+++ b/scripts/jdk25_ios_fixups.py
@@ -16,7 +16,7 @@ from pathlib import Path
 JDK = Path(sys.argv[1] if len(sys.argv) > 1 else 'openjdk-25')
 os.chdir(JDK)
 
-ok = warn = skip = 0
+ok = warn = skip = required_failures = 0
 
 
 def patch(path, transformations, replace_all=False):
@@ -52,6 +52,23 @@ def patch(path, transformations, replace_all=False):
         ok += 1
     else:
         skip += 1
+
+
+def require_postcondition(path, label, markers):
+    """Fail the run unless every marker for a critical fix is present."""
+    global required_failures
+    p = Path(path)
+    if not p.exists():
+        print(f"  [ERROR] required {label}: missing file {path}")
+        required_failures += 1
+        return
+    source = p.read_text()
+    missing = [marker for marker in markers if marker not in source]
+    if missing:
+        print(f"  [ERROR] required {label}: postcondition is not satisfied")
+        required_failures += 1
+    else:
+        print(f"  [REQUIRED] {label}: verified")
 
 
 # 1. flags-ldflags.m4 — comment out OS_LDFLAGS for iOS (keeping JDK 25's
@@ -273,6 +290,42 @@ patch('make/modules/java.desktop/lib/AwtLibraries.gmk', [
      "ifeq ($(call isTargetOs, macosx_NOTIOS), true)\n  ##############################################################################\n  ## Build libawt_lwawt"),
 ])
 
+# 16b. The mirror_mapping patch tried to detect TXM by enumerating
+#      /private/preboot. Apple made that directory unreadable on iOS 26.6,
+#      so opendir returns null and the unchecked readdir call crashes during
+#      CodeCache initialization. MirrorMappedCodeCache is now a contract with
+#      the launcher: it is enabled only after the Universal JIT script has
+#      been installed and the device failed an executable-map capability test.
+#      Consequently HotSpot should always request the debugger mapping when
+#      this flag is enabled; filesystem-based hardware detection is both
+#      redundant and unsafe.
+patch('src/hotspot/os/bsd/os_bsd.cpp', [
+    ("mirror-flag-always-uses-debugger-mapping",
+     "bool DeviceRequiresTXMWorkaround() {\n"
+     "    if(__builtin_available(iOS 19.0, *)) {\n"
+     "        DIR *d = opendir(\"/private/preboot\");\n"
+     "        struct dirent *dir;\n"
+     "        char txmPath[PATH_MAX];\n"
+     "        while ((dir = readdir(d)) != NULL) {\n"
+     "            if(strlen(dir->d_name) == 96) {\n"
+     "                snprintf(txmPath, sizeof(txmPath), \"/private/preboot/%s/usr/standalone/firmware/FUD/Ap,TrustedExecutionMonitor.img4\", dir->d_name);\n"
+     "                break;\n"
+     "            }\n"
+     "        }\n"
+     "        closedir(d);\n"
+     "        return access(txmPath, F_OK) == 0;\n"
+     "    } else {\n"
+     "        return false;\n"
+     "    }\n"
+     "}",
+     "bool DeviceRequiresTXMWorkaround() {\n"
+     "    // The launcher enables MirrorMappedCodeCache only after installing\n"
+     "    // the Universal JIT script and detecting that direct RX mappings\n"
+     "    // are unavailable. Do not inspect Apple's private Preboot layout.\n"
+     "    return true;\n"
+     "}"),
+])
+
 # 17. JDK 21 patch swapped pthread_jit_write_protect_np() for jit_write_protect()
 #     defined in tcg-apple-jit.h, which uses APRR (Apple's old W^X mechanism).
 #     APRR is disabled on iPhone 17 / iOS 26 / A19 Pro (TXM hardware enforcement
@@ -367,6 +420,13 @@ patch('src/hotspot/share/code/nmethod.hpp', [
     ("set-osr-link-mirror-w-set",
      "  void     set_osr_link(nmethod *n) { _osr_link = n; }",
      "  void     set_osr_link(nmethod *n) { mirror_w_set(_osr_link) = n; }"),
+    # The JDK 21 mirror_mapping hunk for this setter was not present in the
+    # published JRE 25. ScavengableNMethodsData inlines it while registering a
+    # compiled method, so the missed conversion writes _gc_data through the RX
+    # alias and raises BUS_ADRALN in ScavengableNMethods::register_nmethod.
+    ("set-gc-data-mirror-w-set",
+     "  void set_gc_data(T* gc_data)                    { _gc_data = reinterpret_cast<void*>(gc_data); }",
+     "  void set_gc_data(T* gc_data)                    { mirror_w_set(_gc_data) = reinterpret_cast<void*>(gc_data); }"),
 ])
 
 # 29. nmethod.cpp Atomic ops + direct field writes that fault when `this`
@@ -806,10 +866,25 @@ patch('src/hotspot/share/code/nmethod.cpp', [
 # Phase 2 ports the mirror_mapping HotSpot patch which uses vm_remap dual
 # mappings instead — that's the only proven JIT path on iOS 26 + TXM.
 
+require_postcondition(
+    'src/hotspot/os/bsd/os_bsd.cpp',
+    'debugger-mapping detector',
+    (
+        'bool DeviceRequiresTXMWorkaround() {',
+        'Do not inspect Apple\'s private Preboot layout.',
+        '    return true;\n}',
+    ),
+)
+require_postcondition(
+    'src/hotspot/share/code/nmethod.hpp',
+    'nmethod GC metadata mirror write',
+    (
+        'void set_gc_data(T* gc_data)',
+        'mirror_w_set(_gc_data) = reinterpret_cast<void*>(gc_data);',
+    ),
+)
+
 print(f"\nfixups: ok={ok} skip={skip} warn={warn}")
-# Don't exit non-zero on WARN — apply_rejs.py + patch -F 100 may have already
-# applied the same change in a slightly different form (e.g. base patch's
-# `ifeq (false, true)` vs fixup's `macosx_NOTIOS`). Both achieve the iOS skip,
-# the file just doesn't have the fixup's expected `old` text anymore. Workflow
-# also wraps this script in `|| echo` for a second layer of defense.
-sys.exit(0)
+if required_failures:
+    print(f"fixups: required failures={required_failures}")
+sys.exit(1 if required_failures else 0)

--- a/scripts/patch_jre25_runtime.py
+++ b/scripts/patch_jre25_runtime.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Patch known mirror-mapping faults in the published iOS JRE 25.
+
+The published libjvm contains DeviceRequiresTXMWorkaround(), which calls
+readdir(opendir("/private/preboot")) without checking whether opendir failed.
+iOS 26.6 made that private directory unreadable, so HotSpot crashes before the
+VM is initialized.
+
+The same build also missed the mirror_w_set() conversion for nmethod::_gc_data.
+On iOS 26.5 it therefore writes GC metadata through the executable alias and
+raises SIGBUS in ScavengableNMethods::register_nmethod. A small trampoline
+translates those writes to the writable alias.
+
+The launcher now enables MirrorMappedCodeCache only after it has installed the
+Universal JIT script and verified that ordinary executable mappings are not
+available. Under that contract the detector must return true. These binary
+fixups are a validated bridge for the pinned 2026-05-09 runtime; the matching
+source-level changes live in jdk25_ios_fixups.py for the next rebuilt JRE.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import struct
+import sys
+from pathlib import Path
+
+
+MH_MAGIC_64 = 0xFEEDFACF
+CPU_TYPE_ARM64 = 0x0100000C
+LC_SEGMENT_64 = 0x19
+LC_SYMTAB = 0x2
+LC_UUID = 0x1B
+
+EXPECTED_RUNTIME_UUID = bytes.fromhex(
+    "63967bf353e2310fa9e7986685040dee"
+)
+ORIGINAL_RUNTIME_SHA256 = (
+    "e249600d12bdb9390bbbf3c857a50ffa"
+    "7dbea578f9120f3931ef8321bb459fd9"
+)
+PATCHED_RUNTIME_SHA256 = (
+    "a5243228b420c4be91530ec742678c999"
+    "ca6751c9b66e4b46af056748c7ca17f"
+)
+
+DETECTOR_SYMBOL = b"__Z27DeviceRequiresTXMWorkaroundv"
+NEXT_SYMBOL = b"__Z21get_debug_jit_mappingm"
+MIRROR_RW_SYMBOL = b"__ZN2os3Bsd16mirrored_find_rwEPh"
+REGISTER_NMETHOD_SYMBOL = (
+    b"__ZN19ScavengableNMethods16register_nmethodEP7nmethod"
+)
+
+# Current jre25-ios-arm64-20260509-release prologue. Checking the full prefix
+# makes an unexpected JRE update fail loudly instead of modifying arbitrary
+# instructions.
+ORIGINAL_PREFIX = bytes.fromhex(
+    "fc6fbda9"  # stp x28, x27, [sp, #-0x30]!
+    "f44f01a9"  # stp x20, x19, [sp, #0x10]
+    "fd7b02a9"  # stp x29, x30, [sp, #0x20]
+    "fd830091"  # add x29, sp, #0x20
+)
+RETURN_TRUE = bytes.fromhex(
+    "20008052"  # mov w0, #1
+    "c0035fd6"  # ret
+)
+
+# DeviceRequiresTXMWorkaround's now-unreachable body is large enough for
+# seven register-specialized entry stubs plus one common store helper.
+# Words are copied from an arm64 assembly fixture and packed below.
+TRAMPOLINE_WORDS = [
+    # A: str x9, [x19, #0x78]
+    0xA9BF07E0, 0x9101E260, 0xAA0903E1, 0x14000019,
+    # B: str x8, [x9]
+    0xA9BF07E0, 0xAA0903E0, 0xAA0803E1, 0x14000015,
+    # C: str xzr, [x19, #0x78]
+    0xA9BF07E0, 0x9101E260, 0xAA1F03E1, 0x14000011,
+    # D: str x8, [x1]
+    0xA9BF07E0, 0xAA0103E0, 0xAA0803E1, 0x1400000D,
+    # E: str xzr, [x0, #0x78]
+    0xA9BF07E0, 0x9101E000, 0xAA1F03E1, 0x14000009,
+    # F: str x13, [x12]
+    0xA9BF07E0, 0xAA0C03E0, 0xAA0D03E1, 0x14000005,
+    # G: str xzr, [x10, #0x78]
+    0xA9BF07E0, 0x9101E140, 0xAA1F03E1, 0x14000001,
+    # Common helper. Preserve every register and NZCV value clobbered by the
+    # exact mirrored_find_rw implementation in the pinned runtime so replacing
+    # a single STR instruction has no observable side effects.
+    # The BL placeholder at word 34 is filled dynamically.
+    0xD10103FF, 0xA90027E8, 0xA9012FEA, 0xA9027BE1,
+    0xD53B4208, 0xF9001BE8, 0x00000000, 0xF94013E1,
+    0xF9000001, 0xF9401BE8, 0xD51B4208, 0xF94017FE,
+    0xA9412FEA, 0xA94027E8, 0x910103FF, 0xA8C107E0,
+    0xD65F03C0,
+]
+TRAMPOLINE_BL_WORD_INDEX = 34
+TRAMPOLINE_ENTRY_OFFSETS = {
+    "A": 0x00,
+    "B": 0x10,
+    "C": 0x20,
+    "D": 0x30,
+    "E": 0x40,
+    "F": 0x50,
+    "G": 0x60,
+}
+
+# Offsets are relative to ScavengableNMethods::register_nmethod in the pinned
+# runtime. Each expected instruction is checked before any write occurs.
+GC_STORE_SITES = [
+    (0x054, "A", "693e00f9"),
+    (0x184, "B", "280100f9"),
+    (0x188, "C", "7f3e00f9"),
+    (0x1A0, "C", "7f3e00f9"),
+    (0x218, "B", "280100f9"),
+    (0x21C, "C", "7f3e00f9"),
+    (0x234, "C", "7f3e00f9"),
+    (0x27C, "D", "280000f9"),
+    (0x280, "E", "1f3c00f9"),
+    (0x298, "E", "1f3c00f9"),
+    (0x334, "B", "280100f9"),
+    (0x338, "C", "7f3e00f9"),
+    (0x350, "C", "7f3e00f9"),
+    (0x3C8, "F", "8d0100f9"),
+    (0x3CC, "G", "5f3d00f9"),
+    (0x3E8, "G", "5f3d00f9"),
+]
+
+
+class PatchError(RuntimeError):
+    pass
+
+
+def _cstring(data: bytes, offset: int, limit: int) -> bytes:
+    if offset < 0 or offset >= limit:
+        raise PatchError(f"invalid Mach-O string offset: {offset}")
+    end = data.find(b"\0", offset, limit)
+    if end < 0:
+        raise PatchError("unterminated Mach-O symbol name")
+    return data[offset:end]
+
+
+def _symbol_location(data: bytes, symbol: bytes) -> tuple[int, int]:
+    if len(data) < 32:
+        raise PatchError("file is too small to be a 64-bit Mach-O")
+
+    magic, cpu_type, _, _, ncmds, sizeofcmds, _, _ = struct.unpack_from(
+        "<IiiIIIII", data, 0
+    )
+    if magic != MH_MAGIC_64:
+        raise PatchError("expected a little-endian 64-bit Mach-O")
+    if cpu_type != CPU_TYPE_ARM64:
+        raise PatchError("expected an arm64 Mach-O")
+    if 32 + sizeofcmds > len(data):
+        raise PatchError("truncated Mach-O load commands")
+
+    segments: list[tuple[int, int, int, int]] = []
+    symtab: tuple[int, int, int, int] | None = None
+    runtime_uuid: bytes | None = None
+    command_offset = 32
+
+    for _ in range(ncmds):
+        if command_offset + 8 > len(data):
+            raise PatchError("truncated Mach-O load command")
+        command, command_size = struct.unpack_from("<II", data, command_offset)
+        if command_size < 8 or command_offset + command_size > len(data):
+            raise PatchError("invalid Mach-O load command size")
+
+        if command == LC_SEGMENT_64:
+            if command_size < 72:
+                raise PatchError("truncated LC_SEGMENT_64 command")
+            vm_address, vm_size, file_offset, file_size = struct.unpack_from(
+                "<QQQQ", data, command_offset + 24
+            )
+            segments.append((vm_address, vm_size, file_offset, file_size))
+        elif command == LC_SYMTAB:
+            if command_size < 24:
+                raise PatchError("truncated LC_SYMTAB command")
+            symtab = struct.unpack_from("<IIII", data, command_offset + 8)
+        elif command == LC_UUID:
+            if command_size < 24:
+                raise PatchError("truncated LC_UUID command")
+            runtime_uuid = data[command_offset + 8:command_offset + 24]
+
+        command_offset += command_size
+
+    if runtime_uuid != EXPECTED_RUNTIME_UUID:
+        actual_uuid = runtime_uuid.hex() if runtime_uuid is not None else "missing"
+        raise PatchError(
+            "unsupported JRE build UUID "
+            f"(expected {EXPECTED_RUNTIME_UUID.hex()}, got {actual_uuid})"
+        )
+    if symtab is None:
+        raise PatchError("Mach-O has no symbol table")
+
+    symbols_offset, symbol_count, strings_offset, strings_size = symtab
+    symbols_end = symbols_offset + symbol_count * 16
+    strings_end = strings_offset + strings_size
+    if symbols_end > len(data) or strings_end > len(data):
+        raise PatchError("truncated Mach-O symbol or string table")
+
+    symbol_address: int | None = None
+    for index in range(symbol_count):
+        entry_offset = symbols_offset + index * 16
+        string_index, _, _, _, value = struct.unpack_from(
+            "<IBBHQ", data, entry_offset
+        )
+        if string_index == 0:
+            continue
+        name = _cstring(
+            data,
+            strings_offset + string_index,
+            strings_end,
+        )
+        if name == symbol:
+            symbol_address = value
+            break
+
+    if symbol_address is None:
+        raise PatchError(f"required symbol not found: {symbol.decode()}")
+
+    for vm_address, _, file_offset, file_size in segments:
+        if vm_address <= symbol_address < vm_address + file_size:
+            result = file_offset + symbol_address - vm_address
+            if result + len(ORIGINAL_PREFIX) > len(data):
+                raise PatchError("symbol points outside the Mach-O file")
+            return symbol_address, result
+
+    raise PatchError("symbol is not backed by a file segment")
+
+
+def _branch(source: int, target: int, link: bool) -> bytes:
+    delta = target - source
+    if delta % 4 != 0:
+        raise PatchError("unaligned arm64 branch target")
+    immediate = delta // 4
+    if not -(1 << 25) <= immediate < (1 << 25):
+        raise PatchError("arm64 branch target is out of range")
+    opcode = 0x94000000 if link else 0x14000000
+    return struct.pack("<I", opcode | (immediate & 0x03FFFFFF))
+
+
+def _trampoline(cave_address: int, mirror_address: int, size: int) -> bytes:
+    words = TRAMPOLINE_WORDS.copy()
+    bl_address = cave_address + TRAMPOLINE_BL_WORD_INDEX * 4
+    words[TRAMPOLINE_BL_WORD_INDEX] = struct.unpack(
+        "<I", _branch(bl_address, mirror_address, link=True)
+    )[0]
+    code = b"".join(struct.pack("<I", word) for word in words)
+    if len(code) > size:
+        raise PatchError("DeviceRequiresTXMWorkaround code cave is too small")
+    nop = struct.pack("<I", 0xD503201F)
+    return code + nop * ((size - len(code)) // 4)
+
+
+def _patch_plan(data: bytes) -> list[tuple[int, bytes, bytes, str]]:
+    detector_address, detector_offset = _symbol_location(data, DETECTOR_SYMBOL)
+    next_address, _ = _symbol_location(data, NEXT_SYMBOL)
+    mirror_address, _ = _symbol_location(data, MIRROR_RW_SYMBOL)
+    register_address, register_offset = _symbol_location(
+        data, REGISTER_NMETHOD_SYMBOL
+    )
+
+    prefix = data[detector_offset:detector_offset + len(ORIGINAL_PREFIX)]
+    if prefix != ORIGINAL_PREFIX and not prefix.startswith(RETURN_TRUE):
+        actual = prefix.hex()
+        raise PatchError(
+            "unsupported DeviceRequiresTXMWorkaround prologue "
+            f"at file offset 0x{detector_offset:x}: {actual}"
+        )
+
+    cave_address = detector_address + len(RETURN_TRUE)
+    cave_offset = detector_offset + len(RETURN_TRUE)
+    cave_size = next_address - cave_address
+    if cave_size <= 0 or cave_size % 4 != 0:
+        raise PatchError("invalid DeviceRequiresTXMWorkaround code cave")
+    trampoline = _trampoline(cave_address, mirror_address, cave_size)
+
+    plan = [
+        (
+            detector_offset,
+            prefix[:len(RETURN_TRUE)],
+            RETURN_TRUE,
+            "TXM detector",
+        ),
+        (
+            cave_offset,
+            data[cave_offset:cave_offset + cave_size],
+            trampoline,
+            "mirror-write trampoline",
+        ),
+    ]
+
+    for relative_offset, entry, expected_hex in GC_STORE_SITES:
+        site_address = register_address + relative_offset
+        site_offset = register_offset + relative_offset
+        expected = bytes.fromhex(expected_hex)
+        patched = _branch(
+            site_address,
+            cave_address + TRAMPOLINE_ENTRY_OFFSETS[entry],
+            link=True,
+        )
+        actual = data[site_offset:site_offset + 4]
+        if actual not in (expected, patched):
+            raise PatchError(
+                "unsupported ScavengableNMethods instruction "
+                f"at file offset 0x{site_offset:x}: {actual.hex()}"
+            )
+        plan.append((
+            site_offset,
+            actual,
+            patched,
+            f"nmethod GC store +0x{relative_offset:x}",
+        ))
+
+    return plan
+
+
+def patch_jvm(path: Path, check_only: bool = False) -> str:
+    data = path.read_bytes()
+    digest = hashlib.sha256(data).hexdigest()
+    if digest not in (ORIGINAL_RUNTIME_SHA256, PATCHED_RUNTIME_SHA256):
+        raise PatchError(
+            "unsupported JRE SHA-256 "
+            f"(expected {ORIGINAL_RUNTIME_SHA256} or "
+            f"{PATCHED_RUNTIME_SHA256}, got {digest})"
+        )
+    plan = _patch_plan(data)
+    pending = [
+        (offset, replacement, label)
+        for offset, actual, replacement, label in plan
+        if actual != replacement
+    ]
+
+    if not pending:
+        return "already patched"
+    if check_only:
+        labels = ", ".join(label for _, _, label in pending)
+        raise PatchError(f"JRE still needs runtime fixups: {labels}")
+
+    with path.open("r+b") as stream:
+        for offset, replacement, _ in pending:
+            stream.seek(offset)
+            stream.write(replacement)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+    verified = path.read_bytes()
+    remaining = [
+        label
+        for offset, _, replacement, label in _patch_plan(verified)
+        if verified[offset:offset + len(replacement)] != replacement
+    ]
+    if remaining:
+        raise PatchError(
+            "patched instructions did not persist: " + ", ".join(remaining)
+        )
+    patched_digest = hashlib.sha256(verified).hexdigest()
+    if patched_digest != PATCHED_RUNTIME_SHA256:
+        raise PatchError(
+            "patched JRE SHA-256 mismatch "
+            f"(expected {PATCHED_RUNTIME_SHA256}, got {patched_digest})"
+        )
+    return f"applied {len(pending)} runtime fixups"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify that the JRE is already patched without modifying it",
+    )
+    parser.add_argument("libjvm", type=Path)
+    args = parser.parse_args()
+
+    try:
+        result = patch_jvm(args.libjvm, args.check)
+    except (OSError, PatchError) as error:
+        print(f"[jre25-patch] ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print(f"[jre25-patch] {result}: {args.libjvm}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/patch_jre_mirror_runtime.py
+++ b/scripts/patch_jre_mirror_runtime.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Enable debugger-backed mirror mappings in the pinned JRE 17 and 21 builds.
+
+Both bundled runtimes already contain Amethyst's MirrorMappedCodeCache support,
+but their DeviceRequiresTXMWorkaround implementations predate the iOS 26.6
+Preboot permission change. JRE 17 returns false and skips the debugger mapping;
+JRE 21 dereferences the failed opendir result. The launcher only enables the
+option after it has established the Universal JIT protocol, so the detector is
+replaced with an unconditional true return.
+
+The full-file hashes, patch offsets, and expected instruction bytes pin this
+bridge to the exact published runtimes. Unknown or partially modified binaries
+are rejected rather than patched heuristically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ORIGINAL_PREFIX = bytes.fromhex(
+    "fc6fbda9"  # stp x28, x27, [sp, #-0x30]!
+    "f44f01a9"  # stp x20, x19, [sp, #0x10]
+    "fd7b02a9"  # stp x29, x30, [sp, #0x20]
+    "fd830091"  # add x29, sp, #0x20
+)
+RETURN_TRUE = bytes.fromhex(
+    "20008052"  # mov w0, #1
+    "c0035fd6"  # ret
+)
+MARKER_NAME = ".amethyst-mirror-mapping"
+MARKER_CONTENT = "amethyst-mirror-mapping-v1\n"
+
+
+@dataclass(frozen=True)
+class RuntimePatch:
+    detector_offset: int
+    original_sha256: str
+    patched_sha256: str
+
+
+RUNTIMES = {
+    17: RuntimePatch(
+        detector_offset=0x7B3CD0,
+        original_sha256=(
+            "c78b4d75f9ab385cf8c5c936bd925816"
+            "31c4a1491ac0208d7e4519e1312b07ab"
+        ),
+        patched_sha256=(
+            "84cc7bc661d27c04f9d1fd178cd258013"
+            "3198826c811e52c16c428ee71c3de50"
+        ),
+    ),
+    21: RuntimePatch(
+        detector_offset=0x81FB8C,
+        original_sha256=(
+            "628ecae014da8029f4b9182ca4eacb53"
+            "c71c42a95e66f88cb7f09164f76a2c35"
+        ),
+        patched_sha256=(
+            "6c56f8af7b967088baf06ea812add9593"
+            "d6b88fcb849a8afae0df688ba7264bd"
+        ),
+    ),
+}
+
+
+class PatchError(RuntimeError):
+    pass
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _marker_path(libjvm: Path) -> Path:
+    try:
+        return libjvm.parents[2] / MARKER_NAME
+    except IndexError as error:
+        raise PatchError("libjvm path is not inside a Java runtime") from error
+
+
+def patch_runtime(
+    runtime_version: int,
+    libjvm: Path,
+    check_only: bool = False,
+) -> str:
+    profile = RUNTIMES[runtime_version]
+    data = libjvm.read_bytes()
+    digest = _sha256(data)
+    marker = _marker_path(libjvm)
+
+    if digest == profile.patched_sha256:
+        if data[
+            profile.detector_offset:
+            profile.detector_offset + len(RETURN_TRUE)
+        ] != RETURN_TRUE:
+            raise PatchError("patched hash has an unexpected detector body")
+        if check_only and marker.read_text(errors="replace") != MARKER_CONTENT:
+            raise PatchError(f"runtime marker is missing or invalid: {marker}")
+        if not check_only:
+            marker.write_text(MARKER_CONTENT)
+        return "already patched"
+
+    if digest != profile.original_sha256:
+        raise PatchError(
+            f"unsupported JRE {runtime_version} SHA-256 "
+            f"(expected {profile.original_sha256} or "
+            f"{profile.patched_sha256}, got {digest})"
+        )
+
+    prefix = data[
+        profile.detector_offset:
+        profile.detector_offset + len(ORIGINAL_PREFIX)
+    ]
+    if prefix != ORIGINAL_PREFIX:
+        raise PatchError(
+            "unexpected DeviceRequiresTXMWorkaround prologue at "
+            f"0x{profile.detector_offset:x}: {prefix.hex()}"
+        )
+    if check_only:
+        raise PatchError("runtime still needs the mirror-mapping detector fix")
+
+    with libjvm.open("r+b") as stream:
+        stream.seek(profile.detector_offset)
+        stream.write(RETURN_TRUE)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+    patched_digest = _sha256(libjvm.read_bytes())
+    if patched_digest != profile.patched_sha256:
+        raise PatchError(
+            "patched runtime hash mismatch "
+            f"(expected {profile.patched_sha256}, got {patched_digest})"
+        )
+    marker.write_text(MARKER_CONTENT)
+    return "applied detector fix"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the runtime and marker without modifying them",
+    )
+    parser.add_argument("runtime_version", type=int, choices=sorted(RUNTIMES))
+    parser.add_argument("libjvm", type=Path)
+    args = parser.parse_args()
+
+    try:
+        result = patch_runtime(
+            args.runtime_version,
+            args.libjvm,
+            args.check,
+        )
+    except (OSError, PatchError) as error:
+        print(f"[jre-mirror-patch] ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        f"[jre-mirror-patch] JRE {args.runtime_version}: "
+        f"{result}: {args.libjvm}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- use MobileGlues for Java 25 Minecraft when the renderer is set to Auto
- select Universal JIT mirror mapping by executable-memory capability and handle iOS 26.6/27 TXM detection
- patch and validate the pinned bundled JRE 17, 21, and 25 runtimes

## Testing

- physical-device IPA testing on iOS 26 and iOS 27 beta
- iOS arm64 native build
- JRE 17/21/25 patch verification
- shell, Python, and diff checks

Addresses #34
Fixes #44
